### PR TITLE
Add more bazel filetypes for detection.

### DIFF
--- a/rc/bazel.kak
+++ b/rc/bazel.kak
@@ -4,7 +4,11 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*/BUILD %{
+hook global BufCreate .*/(BUILD|WORKSPACE) %{
+    set-option buffer filetype bazel_build
+}
+
+hook global BufCreate .+\.(bazel|bzl) %{
     set-option buffer filetype bazel_build
 }
 


### PR DESCRIPTION
Bazel files can have the extensions .bzl or .bazel, WORKSPACE (or WORKSPACE.bazel) are also bazel files. 