### PR TITLE
Added Basic Vlang Highlighter

### DIFF
--- a/rc/v.kak
+++ b/rc/v.kak
@@ -46,25 +46,25 @@ add-highlighter shared/v/comment_line region '//' $ fill comment
 
 add-highlighter shared/v/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9_]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?\.*\b|(none|true|false)\b} 0:value
 
-add-highlighter shared/v/code/ regex \b(chan|err|i8|u8|byte|i16|u16|int|u32|i64|u64|f32|f64|ptr|voidptr|r|size_t|map|rune|string)\b 0:type
-
-add-highlighter shared/v/code/ regex \b(print|println|eprint|eprintln|exit|panic|print_backtrace|dump|rmdir_all|mkdir|exec|ls|mv)\b 0:builtin
-
 add-highlighter shared/v/code/ regex (<|>|=|\+|-|\*|/|%|~|&|\|||\^|!|\?|:=) 0:operator
 
 evaluate-commands %sh{
 	keywords='if as asm assert atomic break const continue else embed enum fn for go import in interface is lock match module mut or pub return rlock select shared sizeof static struct type typeof union __offsetof free unsafe strlen strncmp malloc goto defer'
 	attributes='deprecated inline heap manualfree live direct_array_access typedef windows_stdcall console json: raw'
 	comptime='if else for'
+	types='chan err i8 u8 byte i16 u16 int u32 i64 u64 f32 f64 ptr voidptr r size_t map rune string'
+	functions='print println eprint eprintln exit panic print_backtrace dump'
 
 	join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
 
 	# Add the language's grammar to the static completion list
-	printf %s\\n "declare-option str-list v_static_words $(join "${keywords} ${attributes} ${comptime}" ' ')"
+	printf %s\\n "declare-option str-list v_static_words $(join "${keywords} ${attributes} ${comptime} ${types} ${functions}" ' ')"
 
 	# Highlight keywords
 	printf %s "
 		add-highlighter shared/v/code/ regex (\b($(join "${keywords}" '|'))\b|(\[($(join "${attributes}" '|')([^\]|(^\n)]*))\])|([\$]($(join "${comptime}" '|')))(?:(?![\s+|\{|\}]))*) 0:keyword
+		add-highlighter shared/v/code/ regex \b($(join "${types}" '|'))\b 0:type
+		add-highlighter shared/v/code/ regex \b($(join "${functions}" '|'))\b 0:builtin
 	"
 }
 

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -1,0 +1,54 @@
+##
+## v.kak by Conscat
+##
+
+# https://vlang.io
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+
+hook global BufCreate .+\.(v|vsh) %{
+    set-option buffer filetype v
+}
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+hook global WinSetOption filetype=v %{
+    require-module v
+    add-highlighter window/v ref v
+}
+
+hook global WinSetOption filetype=(?!v).* %{
+    remove-highlighter window/v
+}
+
+hook global BufSetOption filetype=v %{
+    set-option buffer comment_line '//'
+}
+
+provide-module v %§
+
+# Highlighters
+# ‾‾‾‾‾‾‾‾‾‾‾‾
+
+add-highlighter shared/v regions
+add-highlighter shared/v/code default-region group
+
+add-highlighter shared/v/back_string region '`' '`' fill string
+add-highlighter shared/v/double_string region '"' (?<!\\)(\\\\)*" fill string
+add-highlighter shared/v/single_string region "'" (?<!\\)(\\\\)*' fill string
+add-highlighter shared/v/comment region -recurse /\* /\* \*/ fill comment
+add-highlighter shared/v/comment_line region '//' $ fill comment
+
+add-highlighter shared/v/code/ regex (\b(if|as|asm|assert|atomic|break|const|continue|else|embed|enum|fn|for|go|import|in|interface|is|lock|match|module|mut|or|pub|return|rlock|select|shared|sizeof|static|struct|type|typeof|union|__offsetof|free|unsafe|strlen|strncmp|malloc|goto|defer)\b|\$(if|else|for)|\[(deprecated|inline|heap|manualfree|live|direct_array_access|typedef|windows_stdcall|console|json:|raw)([^\]|(^\n)]*)\]) 0:keyword
+
+add-highlighter shared/v/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9_]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?\.*|none|true|false\b} 0:value
+add-highlighter shared/v/code/ regex \b(chan|err|i8|u8|byte|i16|u16|int|u32|i64|u64|f32|f64|ptr|voidptr|r|size_t|map|rune|string)\b 0:type
+
+add-highlighter shared/v/code/ regex \b(print|println|eprint|eprintln|exit|panic|print_backtrace|dump|rmdir_all|mkdir|exec|ls|mv)\b 0:builtin
+
+add-highlighter shared/v/code/ regex (<|>|=|\+|-|\*|/|%|~|&|\|||\^|!|\?|:=) 0:operator
+
+§

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -1,4 +1,5 @@
 ##
+
 ## v.kak by Conscat
 ##
 
@@ -25,9 +26,11 @@ hook global WinSetOption filetype=(?!v).* %{
     remove-highlighter window/v
 }
 
-decl str comment_line
+declare-option str comment_line
 hook global BufSetOption filetype=v %{
     set-option buffer comment_line '//'
+    set-option buffer comment_block_begin '/*'
+    set-option buffer comment_block_end   '*/'
 }
 
 provide-module v %§

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -8,7 +8,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .+\.(v|vsh) %{
+hook global BufCreate .+\.(v|vv|vsh) %{
     set-option buffer filetype v
 }
 
@@ -50,9 +50,9 @@ add-highlighter shared/v/code/ regex (<|>|=|\+|-|\*|/|%|~|&|\|||\^|!|\?|:=) 0:op
 
 evaluate-commands %sh{
 	keywords='if as asm assert atomic break const continue else embed enum fn for go import in interface is lock match module mut or pub return rlock select shared sizeof static struct type typeof union __offsetof free unsafe strlen strncmp malloc goto defer'
-	attributes='deprecated inline heap manualfree live direct_array_access typedef windows_stdcall console json: raw required'
+	attributes='deprecated inline heap manualfree live direct_array_access typedef windows_stdcall console json: raw required export if keep_args_alive unsafe'
 	comptime='if else for'
-	types='chan err i8 u8 byte i16 u16 int u32 i64 u64 f32 f64 ptr voidptr r size_t map rune string bool'
+	types='chan err i8 u8 byte i16 u16 int u32 i64 u64 f32 f64 ptr voidptr size_t map rune string bool'
 	functions='print println eprint eprintln exit panic print_backtrace dump'
 
 	join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -25,6 +25,7 @@ hook global WinSetOption filetype=(?!v).* %{
     remove-highlighter window/v
 }
 
+decl str comment_line
 hook global BufSetOption filetype=v %{
     set-option buffer comment_line '//'
 }

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -17,6 +17,7 @@ hook global BufCreate .+\.(v|vsh) %{
 
 hook global WinSetOption filetype=v %{
     require-module v
+    set-option window static_words %opt{v_static_words}
     add-highlighter window/v ref v
 }
 
@@ -42,13 +43,28 @@ add-highlighter shared/v/single_string region "'" (?<!\\)(\\\\)*' fill string
 add-highlighter shared/v/comment region -recurse /\* /\* \*/ fill comment
 add-highlighter shared/v/comment_line region '//' $ fill comment
 
-add-highlighter shared/v/code/ regex (\b(if|as|asm|assert|atomic|break|const|continue|else|embed|enum|fn|for|go|import|in|interface|is|lock|match|module|mut|or|pub|return|rlock|select|shared|sizeof|static|struct|type|typeof|union|__offsetof|free|unsafe|strlen|strncmp|malloc|goto|defer)\b|\$(if|else|for)|\[(deprecated|inline|heap|manualfree|live|direct_array_access|typedef|windows_stdcall|console|json:|raw)([^\]|(^\n)]*)\]) 0:keyword
-
 add-highlighter shared/v/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9_]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?\.*|none|true|false\b} 0:value
+
 add-highlighter shared/v/code/ regex \b(chan|err|i8|u8|byte|i16|u16|int|u32|i64|u64|f32|f64|ptr|voidptr|r|size_t|map|rune|string)\b 0:type
 
 add-highlighter shared/v/code/ regex \b(print|println|eprint|eprintln|exit|panic|print_backtrace|dump|rmdir_all|mkdir|exec|ls|mv)\b 0:builtin
 
 add-highlighter shared/v/code/ regex (<|>|=|\+|-|\*|/|%|~|&|\|||\^|!|\?|:=) 0:operator
+
+evaluate-commands %sh{
+	keywords='if as asm assert atomic break const continue else embed enum fn for go import in interface is lock match module mut or pub return rlock select shared sizeof static struct type typeof union __offsetof free unsafe strlen strncmp malloc goto defer'
+	attributes='deprecated inline heap manualfree live direct_array_access typedef windows_stdcall console json: raw'
+	comptime='if else for'
+
+	join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
+
+	# Add the language's grammar to the static completion list
+	printf %s\\n "declare-option str-list v_static_words $(join "${keywords} ${attributes} ${comptime}" ' ')"
+
+	# Highlight keywords
+	printf %s "
+		add-highlighter shared/v/code/ regex (\b($(join "${keywords}" '|'))\b|(\[($(join "${attributes}" '|')([^\]|(^\n)]*))\])|([\$]($(join "${comptime}" '|')))(?:(?![\s+|\{|\}]))*) 0:keyword
+	"
+}
 
 §

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -50,9 +50,9 @@ add-highlighter shared/v/code/ regex (<|>|=|\+|-|\*|/|%|~|&|\|||\^|!|\?|:=) 0:op
 
 evaluate-commands %sh{
 	keywords='if as asm assert atomic break const continue else embed enum fn for go import in interface is lock match module mut or pub return rlock select shared sizeof static struct type typeof union __offsetof free unsafe strlen strncmp malloc goto defer'
-	attributes='deprecated inline heap manualfree live direct_array_access typedef windows_stdcall console json: raw'
+	attributes='deprecated inline heap manualfree live direct_array_access typedef windows_stdcall console json: raw required'
 	comptime='if else for'
-	types='chan err i8 u8 byte i16 u16 int u32 i64 u64 f32 f64 ptr voidptr r size_t map rune string'
+	types='chan err i8 u8 byte i16 u16 int u32 i64 u64 f32 f64 ptr voidptr r size_t map rune string bool'
 	functions='print println eprint eprintln exit panic print_backtrace dump'
 
 	join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
@@ -62,7 +62,7 @@ evaluate-commands %sh{
 
 	# Highlight keywords
 	printf %s "
-		add-highlighter shared/v/code/ regex (\b($(join "${keywords}" '|'))\b|(\[($(join "${attributes}" '|')([^\]|(^\n)]*))\])|([\$]($(join "${comptime}" '|')))(?:(?![\s+|\{|\}]))*) 0:keyword
+		add-highlighter shared/v/code/ regex (\b((?<![@])($(join "${keywords}" '|')))\b|(\[($(join "${attributes}" '|')([^\]|(^\n)]*))\])|([\$]($(join "${comptime}" '|')))(?:(?![\s+|\{|\}]))*) 0:keyword
 		add-highlighter shared/v/code/ regex \b($(join "${types}" '|'))\b 0:type
 		add-highlighter shared/v/code/ regex \b($(join "${functions}" '|'))\b 0:builtin
 	"

--- a/rc/v.kak
+++ b/rc/v.kak
@@ -44,7 +44,7 @@ add-highlighter shared/v/single_string region "'" (?<!\\)(\\\\)*' fill string
 add-highlighter shared/v/comment region -recurse /\* /\* \*/ fill comment
 add-highlighter shared/v/comment_line region '//' $ fill comment
 
-add-highlighter shared/v/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9_]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?\.*|none|true|false\b} 0:value
+add-highlighter shared/v/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9_]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?\.*\b|(none|true|false)\b} 0:value
 
 add-highlighter shared/v/code/ regex \b(chan|err|i8|u8|byte|i16|u16|int|u32|i64|u64|f32|f64|ptr|voidptr|r|size_t|map|rune|string)\b 0:type
 


### PR DESCRIPTION
I've created a highlighter for the [V language](https://github.com/vlang/v/). This is generally modeled after the Go highlighter, since V is largely modeled after Go. This uses the file extensions `.v` and `.vsh`, the former of which conflicts with the built-in Verilog highlighter. Perhaps this should be moved into a different folder, so it doesn't get autoloaded? Or maybe Kakoune needs a more sophisticated language-detection feature.

Unlike go.kak, this does not currently provide indentation hooks. There are also ways in which the highlighter could be more sophisticated. Certainly room for improvement in future commits, if this is merged.